### PR TITLE
added a button for rec of the week, chatgpt code for weekly rec, upda…

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -49,3 +49,17 @@
   background: #f0e4fa;
   color: #1b171f;
 }
+
+.btn-ghost {
+  color: #4A4A4A;
+  border: 1px solid #4A4A4A;
+  padding: 4px 10px;
+  border-radius: 50px;
+  font-weight: lighter;
+  opacity: 0.5;
+  transition: opacity 0.8s ease;
+}
+
+.btn-ghost:hover {
+  opacity: .8;
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,5 +4,71 @@ class PagesController < ApplicationController
 
   def home
     @joy = Joy.new
+
+    # # # call another method:
+    # run_weekly_task if Time.now.friday? && Time.now.hour >= 0
+
+    # 2nd version of calling the mthod below but only triggers once every friday anytime user arrives to home
+    # and will not run code again if ran already
+    if Time.now.friday? && Time.now.hour >= 0
+      unless session[:weekly_task_executed]
+        run_weekly_task
+        session[:weekly_task_executed] = true
+      end
+    else
+      session[:weekly_task_executed] = false
+    end
   end
+
+
+  private
+
+  def run_weekly_task
+    # Your weekly task logic here
+    # code below creates a reccomendation from the joys within a period from current_user
+    @user = current_user
+    startdate = Date.today.prev_occurring(:friday)
+    # enddate = startdate + 6.days
+    enddate = startdate + 7.days
+    @joys = @user.joys.where(created_at: startdate...enddate)
+    # @joys = @user.joys
+
+    descriptions = @joys.map { |joy| joy.description }
+
+    @response = OpenaiService.new("You are JoyJot, a cheerful motivational chatbot friend. I will provide you with an array of strings about my joys from this week, and it will be your job to come up with strategies that can help me achieve further happiness, max 100 words. Only do one of the following: If the request contains strings, suggest 2 activities I can do this weekend to continue feeling joy. Otherwise, provide 3 ideas on how to find joy.
+
+      The following request is an array of strings detailing things that brought me joy this week: #{descriptions}").call
+
+    # @response = OpenaiService.new("You are JoyJot, a cheerful motivational chatbot friend. count how many strings I have in this array and tell me the number and a joke: #{descriptions}").call
+    @my_reccomendation = Recommendation.new
+    @my_reccomendation.user = current_user
+    @my_reccomendation.activity = @response # Assign the OpenAI response to the 'fortune' attribute
+    # @my_reccomendation.activity = descriptions
+    @my_reccomendation.save
+  end
+
 end
+
+  # @response = OpenaiService.new("You are JoyJot, a cheerful motivational chatbot friend. I will provide you with an array of strings about my joys from this week, and it will be your job to come up with strategies that can help me achieve further happiness, max 100 words. Only do one of the following: If the request contains strings, suggest 2 activities I can do this weekend to continue feeling joy. Otherwise, provide 3 ideas on how to find joy.
+
+  #   The following request is an array of strings detailing things that brought me joy this week: #{descriptions}").call
+
+  #   # # testing code
+    # # Your weekly task logic here
+    # # code below creates a reccomendation from the joys within a period from current_user
+    # @user = current_user
+    # # startdate = Date.today.prev_occurring(:friday)
+    # # # enddate = startdate + 6.days
+    # # enddate = startdate + 6.days
+    # # @joys = @user.joys.where(created_at: startdate...enddate)
+    # @joys = @user.joys
+
+    # descriptions = @joys.map { |joy| joy.description }
+
+
+    # # @response = OpenaiService.new("You are JoyJot, a cheerful motivational chatbot friend. count how many strings I have in this array and tell me the number and a joke: #{descriptions}").call
+    # @my_reccomendation = Recommendation.new
+    # @my_reccomendation.user = current_user
+    # # @my_reccomendation.activity = @response # Assign the OpenAI response to the 'fortune' attribute
+    # @my_reccomendation.activity = descriptions
+    # @my_reccomendation.save

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -17,16 +17,18 @@ class RecommendationsController < ApplicationController
     @recommendation = set_recommendations
     @user = current_user
     startdate = Date.today.prev_occurring(:friday)
-    enddate = startdate + 6.days
+    # enddate = startdate + 6.days
+    enddate = startdate + 7.days
     @joys = @user.joys.where(created_at: startdate...enddate)
     joy_ratings = @joys.map do |joy|
-      joy.rating
+      # || operator to convert any nil ratings to 0 when building the joy_ratings array.
+      joy.rating || 0  # Convert nil ratings to 0
     end
-    if @joys.empty?
-      @ave_rating = 0
-    else
-      @ave_rating = (joy_ratings.sum.to_f / @joys.count).round(1)
-    end
+    # if joy_ratings.empty?
+    #   @ave_rating = 0
+    # else
+    @ave_rating = (joy_ratings.sum.to_f / joy_ratings.count).round(1)
+    # end
   end
 
   private

--- a/app/views/joys/index.html.erb
+++ b/app/views/joys/index.html.erb
@@ -16,7 +16,7 @@
         <tbody>
           <% @joys.each do |joy| %>
             <tr>
-              <td><%= joy.description[0, 10] %>...</td>
+              <td><%= joy.description[0, 15] %>...</td>
               <!-- <td><%= joy.genre %></td> -->
               <td><%= joy.rating %></td>
             </tr>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,7 +1,12 @@
+<div>
+  <a class="btn btn-ghost" href="/recommendations">Happy Friday! Your Weekly Reccomendations Are Ready!</a>
+</div>
+
 <div class="container mt-5">
   <div class="row">
     <div class="col-md-6 offset-md-3 col-lg-4 offset-lg-4">
       <%= render 'joys/joy_form' %>
+
 
       <div class="mt-4">
         <button type="submit" class="btn btn-inspire btn-block">Inspire me...</button>

--- a/app/views/recommendations/show.html.erb
+++ b/app/views/recommendations/show.html.erb
@@ -6,7 +6,7 @@
       <div class="reco-stats mt-4">
         <h5 class="mt-5">Insights:</h5>
         <ul>
-          <li>You had <strong><%= @joys.count %></strong> joys this week <i class="fa-solid fa-heart" style="color: #ff94d8;"></i></li>
+          <li>You had <strong><%= @joys.size %></strong> joys this week <i class="fa-solid fa-heart" style="color: #ff94d8;"></i></li>
           <li>Your average joy rating was <strong><%= @ave_rating %></strong> <i class="fas fa-star" style="color: #ffc800"></i></li>
         </ul>
       </div>


### PR DESCRIPTION
…ted ave rating bug, tweaked the views to work w/ new linking butto but btn not finished yet, only links to weekly rec

in short i did the following:

added a btn from home to rec index signaling weekly rec is ready(still very rough btw could use styling and stimulus which I will look into today to make it appear only friday and disappear after clicked
fixed rec show bug w/ average rating not working if rating was nil
chatgpt trigger code implemented in home and triggers when it is friday anytime and if the user is signed in (if user never shows up on Friday they may miss out on recommendation... open to ideas how to account for this. Maybe incentive to log in on fridays)
rec is functional and displays properly on index and show(takes 7-10 seconds too create from home)

Pics attached below. Plz rev and thanks
<img width="1440" alt="Screenshot 2023-08-18 at 11 19 17 AM" src="https://github.com/chrisram415/JOYJOT/assets/128114688/0055db6f-47a5-42f3-89ec-b3de16429bb2">
<img width="1440" alt="Screenshot 2023-08-18 at 11 19 04 AM" src="https://github.com/chrisram415/JOYJOT/assets/128114688/64579427-8f4b-4645-876a-6a3966ab322d">
<img width="1440" alt="Screenshot 2023-08-18 at 11 06 43 AM" src="https://github.com/chrisram415/JOYJOT/assets/128114688/e1916b5c-5948-43c6-a8ea-76a555a99ae7">
<img width="1440" alt="Screenshot 2023-08-18 at 11 49 33 AM" src="https://github.com/chrisram415/JOYJOT/assets/128114688/a1eecf60-f676-464d-850a-0b693ffa2cc6">
